### PR TITLE
Base the timer on an actual time instead of a counter

### DIFF
--- a/script.js
+++ b/script.js
@@ -100,11 +100,13 @@ async function fetchData() {
 
 function startCountdown() {
   const fetchButton = document.getElementById("fetch-button");
-  let remainingTime = 30;
+  const startTime = Date.now();
+  const countdownSeconds = 30;
 
   clearInterval(timer);
   timer = setInterval(() => {
-    remainingTime--;
+    const secondsSinceStart = (Date.now() - startTime) / 1000;
+    const remainingTime = Math.ceil(Math.max(0, countdownSeconds - secondsSinceStart));
     fetchButton.textContent = `Fetch (${remainingTime}s)`;
 
     if (remainingTime <= 0) {

--- a/script.js
+++ b/script.js
@@ -106,13 +106,14 @@ function startCountdown() {
   clearInterval(timer);
   timer = setInterval(() => {
     const secondsSinceStart = Math.floor((Date.now() - startTime) / 1000);
-    const remainingTime = Math.max(0, countdownSeconds - secondsSinceStart);
-    fetchButton.textContent = `Fetch (${remainingTime}s)`;
+    const remainingTime = countdownSeconds - secondsSinceStart;
 
     if (remainingTime <= 0) {
       clearInterval(timer);
       fetchButton.textContent = "Fetch";
       fetchButton.disabled = false;
+    } else {
+      fetchButton.textContent = `Fetch (${remainingTime}s)`;
     }
   }, 1000);
 }

--- a/script.js
+++ b/script.js
@@ -105,8 +105,8 @@ function startCountdown() {
 
   clearInterval(timer);
   timer = setInterval(() => {
-    const secondsSinceStart = (Date.now() - startTime) / 1000;
-    const remainingTime = Math.ceil(Math.max(0, countdownSeconds - secondsSinceStart));
+    const secondsSinceStart = Math.floor((Date.now() - startTime) / 1000);
+    const remainingTime = Math.max(0, countdownSeconds - secondsSinceStart);
     fetchButton.textContent = `Fetch (${remainingTime}s)`;
 
     if (remainingTime <= 0) {


### PR DESCRIPTION
Some browsers suspend timers when pages are in the background. I'm not sure of the full list, but Firefox on Android is one. This resulted in the timer being effectively paused after navigating to a new tab (eg, after clicking "Attack" next to a player), then when you would return to the page there would still be a nearly full countdown remaining.

This PR changes the countdown so that it is based on the actual time, so that in the case where a timer was suspended, it will still properly resume the countdown at the point that it should be (or more likely just be done with the countdown).