### PR TITLE
Bump script version to 1.36

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       defer
       src="https://cdn.jsdelivr.net/npm/alpinejs@3.12.0/dist/cdn.min.js"
     ></script>
-    <script src="script.js?v=1.35"></script>
+    <script src="script.js?v=1.36"></script>
   </head>
 
   <body


### PR DESCRIPTION
I'm not sure what determines the script version number, but this appears to be the one that contains the latest changes. It didn't get updated with the last merge so the correct script isn't being used.