### PR TITLE
Fix background right svg

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
           <rect width="404" height="784" fill="url(#left-pattern)"></rect>
         </svg>
         <svg
-          class="absolute left-full transform -translate-y-1/2 -translate-x-1/8 md:-translate-y-1/2 lg:-translate-x-1/4"
+          class="absolute left-full transform -translate-y-1/8 -translate-x-1/8 lg:-translate-x-1/4"
           width="404"
           height="784"
           fill="none"


### PR DESCRIPTION
For some reason the SVG on the right was not going all the way down like the left one 

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/ee29d3f7-9f31-460a-ae45-59e7a2fb4f8a" />
