### PR TITLE
feat: Highlight table row once Attack is clicked

### DIFF
--- a/script.js
+++ b/script.js
@@ -327,10 +327,21 @@ function hideDataTable() {
   dataTable.classList.add("hidden");
 }
 
+function highlightRow(button) {
+  document.querySelectorAll("#table-body tr.bg-blue-950").forEach(row => {
+    row.classList.remove("bg-blue-950");
+  });
+
+  const row = button.closest("tr");
+  if (row) {
+    row.classList.add("bg-blue-950");
+  }
+}
+
 function createAttackLink(id, status) {
   const isDisabled = status !== "Okay";
   const disabledClass = isDisabled ? "cursor-not-allowed opacity-30 hover:bg-white dark:hover:bg-gray-800" : "hover:bg-gray-50 dark:hover:bg-gray-700";
-  const onClick = isDisabled ? "event.preventDefault();" : "";
+  const onClick = isDisabled ? "event.preventDefault();" : "highlightRow(this)";
 
   return `<a target="_blank" href="https://www.torn.com/loader2.php?sid=getInAttack&user2ID=${id}" class="inline-flex items-center rounded-md bg-white dark:bg-gray-800 px-2.5 py-1.5 text-sm font-semibold text-gray-900 dark:text-gray-300 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 ${disabledClass}" onclick="${onClick}">Attack</a>`;
 }


### PR DESCRIPTION
Discussed on Discord, basically whenever you click on Attack this change will highlight the row in a lighter color so that you can keep track of who you've attacked last and can easily identify who to attack next.

<img width="2393" height="1281" alt="Screenshot_4" src="https://github.com/user-attachments/assets/2f17a7fa-3b1a-4552-9b91-a4b03b2273f5" />
