### PR TITLE
feat: implement sortable columns in player table

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,51 +209,67 @@
                         <tr>
                           <th
                             scope="col"
-                            class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 sm:pl-6"
+                            data-col="name"
+                            onclick="sortTable('name')"
+                            class="cursor-pointer select-none py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 sm:pl-6"
                           >
-                            Player
+                            Player<span class="sort-icon text-gray-400"> ↕</span>
                           </th>
                           <th
                             scope="col"
-                            class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 lg:table-cell"
+                            data-col="lvl"
+                            onclick="sortTable('lvl')"
+                            class="cursor-pointer select-none hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 lg:table-cell"
                           >
-                            Level
+                            Level<span class="sort-icon text-gray-400"> ↕</span>
                           </th>
                           <th
                             scope="col"
-                            class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 lg:table-cell"
+                            data-col="total"
+                            onclick="sortTable('total')"
+                            class="cursor-pointer select-none hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 lg:table-cell"
                           >
-                            Total
+                            Total<span class="sort-icon text-gray-400"> ↕</span>
                           </th>
                           <th
                             scope="col"
-                            class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 lg:table-cell"
+                            data-col="str"
+                            onclick="sortTable('str')"
+                            class="cursor-pointer select-none hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 lg:table-cell"
                           >
-                            Strength
+                            Strength<span class="sort-icon text-gray-400"> ↕</span>
                           </th>
                           <th
                             scope="col"
-                            class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 lg:table-cell"
+                            data-col="def"
+                            onclick="sortTable('def')"
+                            class="cursor-pointer select-none hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 lg:table-cell"
                           >
-                            Defense
+                            Defense<span class="sort-icon text-gray-400"> ↕</span>
                           </th>
                           <th
                             scope="col"
-                            class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 lg:table-cell"
+                            data-col="spd"
+                            onclick="sortTable('spd')"
+                            class="cursor-pointer select-none hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 lg:table-cell"
                           >
-                            Speed
+                            Speed<span class="sort-icon text-gray-400"> ↕</span>
                           </th>
                           <th
                             scope="col"
-                            class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 lg:table-cell"
+                            data-col="dex"
+                            onclick="sortTable('dex')"
+                            class="cursor-pointer select-none hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300 lg:table-cell"
                           >
-                            Dexterity
+                            Dexterity<span class="sort-icon text-gray-400"> ↕</span>
                           </th>
                           <th
                             scope="col"
-                            class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300"
+                            data-col="status"
+                            onclick="sortTable('status')"
+                            class="cursor-pointer select-none px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-300"
                           >
-                            Status
+                            Status<span class="sort-icon text-gray-400"> ↕</span>
                           </th>
                           <th
                             scope="col"

--- a/script.js
+++ b/script.js
@@ -1,4 +1,6 @@
 let tableData = [];
+let renderedUsers = [];
+let currentSort = { col: null, dir: 'asc' };
 let timer;
 let statusUpdateInterval;
 
@@ -181,11 +183,10 @@ async function fetchData() {
             return aRemaining - bRemaining;
         });
 
-        sortedUsers.forEach((user, index) => {
-            const attackLink = createAttackLink(user.id, user.status);
-            const newRow = createTableRow(user, user.status, attackLink, index);
-            tableBody.innerHTML += newRow;
-        });
+        renderedUsers = sortedUsers;
+        currentSort = { col: null, dir: 'asc' };
+        renderTable(renderedUsers);
+        updateSortIndicators();
 
         hideNoDataMessage();
         displayDataTable();
@@ -392,6 +393,58 @@ function createTableRow(row, status, attackLink, index) {
       </td>
     </tr>
   `;
+}
+
+
+function renderTable(users) {
+  const tableBody = document.getElementById("table-body");
+  tableBody.innerHTML = "";
+  users.forEach((user, index) => {
+    const attackLink = createAttackLink(user.id, user.status);
+    tableBody.innerHTML += createTableRow(user, user.status, attackLink, index);
+  });
+}
+
+function statusSortValue(status) {
+  if (status === 'Okay') return -1;
+  const remaining = parseHospitalTime(status);
+  return remaining === Infinity ? Number.MAX_SAFE_INTEGER : remaining;
+}
+
+function sortTable(col) {
+  if (currentSort.col === col) {
+    currentSort.dir = currentSort.dir === 'asc' ? 'desc' : 'asc';
+  } else {
+    currentSort.col = col;
+    currentSort.dir = 'asc';
+  }
+
+  const sorted = [...renderedUsers].sort((a, b) => {
+    const dir = currentSort.dir === 'asc' ? 1 : -1;
+    if (col === 'status') {
+      return dir * (statusSortValue(a.status) - statusSortValue(b.status));
+    }
+    if (col === 'name') {
+      return dir * a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+    }
+    return dir * (a[col] - b[col]);
+  });
+
+  renderTable(sorted);
+  updateSortIndicators();
+}
+
+function updateSortIndicators() {
+  document.querySelectorAll('th[data-col]').forEach(th => {
+    const span = th.querySelector('.sort-icon');
+    if (!span) return;
+    const col = th.dataset.col;
+    if (col === currentSort.col) {
+      span.textContent = currentSort.dir === 'asc' ? ' ↑' : ' ↓';
+    } else {
+      span.textContent = ' ↕';
+    }
+  });
 }
 
 function showCustomPopup(message) {


### PR DESCRIPTION
Adds the ability to sort the player list by clicking any column header.

- Clicking a column header sorts ascending (↑), clicking again sorts descending (↓)
- All columns are sortable: Player, Level, Total, Strength, Defense, Speed, Dexterity, Status
- Status column sorts by attackability — Okay players first, then by shortest hospital time remaining
- Sort state resets automatically when fetching new data
- Active sort is preserved correctly across live hospital countdown updates